### PR TITLE
WIP: Add ability to load LIBPS and multiple datafiles with PSXSERIAL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+libps.exe
+libmon22.exe

--- a/pypsxserial.py
+++ b/pypsxserial.py
@@ -38,54 +38,57 @@
 #    close port
 #
 
+import argparse
 import serial
 import sys
 import time
 
-if len(sys.argv) < 3:
-    print("usage: pypsxserial.py <FILE_TO_UPLOAD.EXE> <SERIAL_PORT_DEVICE>\n")
-    print("example port devices:\n   /dev/cu.usbserial (macOS - avoid tty.*)\n   /dev/ttyUSB0 (linux)\n   COM1 (windows)\n")
-    quit(-1)
 
-filename = sys.argv[1]
-ttydevice = sys.argv[2]
+if __name__ == '__main__':
+    if len(sys.argv) < 3:
+        print("usage: pypsxserial.py <FILE_TO_UPLOAD.EXE> <SERIAL_PORT_DEVICE>\n")
+        print("example port devices:\n   /dev/cu.usbserial (macOS - avoid tty.*)\n   /dev/ttyUSB0 (linux)\n   COM1 (windows)\n")
+        quit(-1)
 
-try:
-    filedata=open(filename,"rb").read()
-    filelen=len(filedata)
-    with serial.Serial(ttydevice,115200) as ser:
-        print(f'using serial port: {ser.name}')
-        print("sending start command 0x63...",end="")
-        ser.write(b'\x63')
-        print("done. reading response...")
-        data=ser.read(1)
-        print(f'response received: {data}')
-        print("having a little nap...")
-        time.sleep(1)
-        print("sending header....",end="")
-        ser.write(filedata[0:2048])
-        print(",PC...",end="")
-        ser.write(filedata[16:20])
-        print(",writeaddr...",end="")
-        ser.write(filedata[24:28])
-        print(",writelen...")
-        ser.write(filedata[28:32])
-        print("now sending file contents:")
-        chunks = (int)((filelen-(filelen%2048))/2048)
-        for x in range(chunks):
-            print(f'chunk: {x}')
-            ser.write(filedata[(x+1)*2048:(x+2)*2048])
-        print("writing remaining bytes")
-        ser.write(filedata[(chunks*2048):(chunks*2048)+(filelen%2048)])
-        print("sending close & execute command...")
-        finalchunk = b''
-        for x in range(2048):
-            finalchunk += b'\xff'
-        ser.write(finalchunk)
-        print("done!")
-        ser.close()
-except:
-    print("something error happens")
-finally:
-    #need a sleep, to avoid bad driver bugs
-    time.sleep(2)
+    filename = sys.argv[1]
+    ttydevice = sys.argv[2]
+
+    try:
+        filedata = open(filename, 'rb').read()
+        filelen = len(filedata)
+        with serial.Serial(ttydevice, 115200) as ser:
+            print(f'using serial port: {ser.name}')
+            print("sending start command 0x63...", end="")
+            ser.write(b'\x63')
+            print("done. reading response...")
+            data=ser.read(1)
+            print(f'response received: {data}')
+            print("having a little nap...")
+            time.sleep(1)
+            print("sending header....", end="")
+            ser.write(filedata[0:2048])
+            print(",PC...", end="")
+            ser.write(filedata[16:20])
+            print(",writeaddr...", end="")
+            ser.write(filedata[24:28])
+            print(",writelen...")
+            ser.write(filedata[28:32])
+            print("now sending file contents:")
+            chunks = (int)((filelen - (filelen % 2048)) / 2048)
+            for x in range(chunks):
+                print(f'chunk: {x}')
+                ser.write(filedata[(x + 1) * 2048:(x + 2) * 2048])
+            print("writing remaining bytes")
+            ser.write(filedata[(chunks * 2048):(chunks * 2048) + (filelen % 2048)])
+            print("sending close & execute command...")
+            finalchunk = b''
+            for x in range(2048):
+                finalchunk += b'\xff'
+            ser.write(finalchunk)
+            print("done!")
+    except Exception as e:
+        print("something error happens")
+        raise e  # Let's see what it is...
+    finally:
+        # need a sleep, to avoid bad driver bugs
+        time.sleep(2)

--- a/pypsxserial.py
+++ b/pypsxserial.py
@@ -43,14 +43,16 @@ import serial
 import sys
 import time
 
+
 PSXSERIAL = 0x801ecd94  # PC for PSXSERIAL v1.3
+
 
 def fake_header(addr: int, filelen: int):
     # Return a fake header to send with data files.
     header = bytearray('PS-X EXE', 'ascii')
     header.extend(bytes(2040))
-    header[0x10:0x13] = PSXSERIAL.to_bytes(4, 'little')
-    header[0x18:0x1B] = addr.to_bytes(4, 'little')
+    header[16:20] = PSXSERIAL.to_bytes(4, 'little')
+    header[24:28] = addr.to_bytes(4, 'little')
     header[28:32] = filelen.to_bytes(4, 'little')
     return header
 
@@ -77,11 +79,11 @@ if __name__ == '__main__':
             print("having a little nap...")
             time.sleep(1)
 
-            if filename.endswith('.exe'):
+            if filename.lower().endswith('.exe'):
                 header = filedata[0:2048]
                 chunkoffset = 1
-            elif filename.endswith('.tim'):
-                header = fake_header(0x80120000, filelen)
+            elif filename.lower().endswith('.tim'):
+                header = fake_header(0x80120000, filelen)  # addr is hardcoded for testing, TODO: read from .sio or args
                 chunkoffset = 0
             pc = header[16:20]
             addr = header[24:28]

--- a/pypsxserial.py
+++ b/pypsxserial.py
@@ -42,7 +42,7 @@ import argparse
 import serial
 from time import sleep
 
-
+LIBPS = ['libmon22.exe', 'libps.exe']  # LIBPS library alternatives in order of preference
 PSXSERIAL = 0x801ecd94  # PC for PSXSERIAL v1.3
 
 
@@ -61,6 +61,7 @@ def main():
     parser.add_argument('filename', help="file to upload")
     parser.add_argument('ttydevice', help="example port devices:\n   /dev/cu.usbserial (macOS - avoid tty.*)\n   /dev/ttyUSB0 (linux)\n   COM1 (windows)\n")
     parser.add_argument('--addr', '-a', help="memory address (hex) to load the file to (if not a PS-X EXE) e.g. 0x80120000")
+    parser.add_argument('--libps', help="send libps.exe (or equivalent) library before running filename", action='store_true')
     args = parser.parse_args()
 
     filename = args.filename

--- a/pypsxserial.py
+++ b/pypsxserial.py
@@ -43,10 +43,16 @@ import serial
 import sys
 import time
 
+PSXSERIAL = 0x801ecd94  # PC for PSXSERIAL v1.3
 
-def fake_header(addr: int):
+def fake_header(addr: int, filelen: int):
     # Return a fake header to send with data files.
-    pass
+    header = bytearray('PS-X EXE', 'ascii')
+    header.extend(bytes(2040))
+    header[0x10:0x13] = PSXSERIAL.to_bytes(4, 'little')
+    header[0x18:0x1B] = addr.to_bytes(4, 'little')
+    header[28:32] = filelen.to_bytes(4, 'little')
+    return header
 
 
 if __name__ == '__main__':
@@ -75,7 +81,7 @@ if __name__ == '__main__':
                 header = filedata[0:2048]
                 chunkoffset = 1
             elif filename.endswith('.tim'):
-                header = fake_header(0x80120000)
+                header = fake_header(0x80120000, filelen)
                 chunkoffset = 0
             pc = header[16:20]
             addr = header[24:28]

--- a/pypsxserial.py
+++ b/pypsxserial.py
@@ -40,8 +40,7 @@
 
 import argparse
 import serial
-import sys
-import time
+from time import sleep
 
 
 PSXSERIAL = 0x801ecd94  # PC for PSXSERIAL v1.3
@@ -57,14 +56,14 @@ def fake_header(addr: int, filelen: int):
     return header
 
 
-if __name__ == '__main__':
-    if len(sys.argv) < 3:
-        print("usage: pypsxserial.py <FILE_TO_UPLOAD.EXE> <SERIAL_PORT_DEVICE>\n")
-        print("example port devices:\n   /dev/cu.usbserial (macOS - avoid tty.*)\n   /dev/ttyUSB0 (linux)\n   COM1 (windows)\n")
-        quit(-1)
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('filename', help="file to upload")
+    parser.add_argument('ttydevice', help="example port devices:\n   /dev/cu.usbserial (macOS - avoid tty.*)\n   /dev/ttyUSB0 (linux)\n   COM1 (windows)\n")
+    args = parser.parse_args()
 
-    filename = sys.argv[1]
-    ttydevice = sys.argv[2]
+    filename = args.filename
+    ttydevice = args.ttydevice
 
     try:
         filedata = open(filename, 'rb').read()
@@ -77,7 +76,7 @@ if __name__ == '__main__':
             data=ser.read(1)
             print(f'response received: {data}')
             print("having a little nap...")
-            time.sleep(1)
+            sleep(1)
 
             if filename.lower().endswith('.exe'):
                 header = filedata[0:2048]
@@ -114,4 +113,8 @@ if __name__ == '__main__':
         raise e  # Let's see what it is...
     finally:
         # need a sleep, to avoid bad driver bugs
-        time.sleep(2)
+        sleep(2)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This adds the ability to send multiple files, including the libps.exe (or libmon22.exe, which provides the same library and the patched Yaroze CIP2.2 mon.exe), and datafiles before sending a final PS-X EXE to run.

**PURPOSE:** to load multi-file Yaroze style projects with other serial receivers, and 3 wire serial cables. (I have misplaced my CIP disc...)

Currently only works with PSXSERIAL v1.3

I don't think PSXSERIAL comes with features to handle multiple files by default. This modifies the python client to send files and returns control back to PSXSERIAL for the next file by modifying PC values.

The versions of libps.exe need to have a modified PC in their headers altered to return control back to PSXSERIAL after loading them.

**TODO**
- [ ] Add an `--libps` arg to send libps, and patch the header as it is sent.

Datafiles are send by creating a fake header on the fly with the correct address to load the data, and the PSXSERIAL PC.

**TODO**
- [ ] Get the Unirom PC and whatever other serial programs are supported  so this can work with more PSX receivers.
- [ ] Accept and parse siocons loading script files

Example current usage:
To load [Hitmen](https://hitmen.c02.at/html/psx_releases.html)'s Remembers Amiga Demo, which requires libps.exe:

    python3 pypsxserial.py libps_psxserial.exe /dev/ttyUSB0
    python3 pypsxserial.py hit-remami/intro.exe /dev/ttyUSB0

When I add the `--libps` arg, this will work with:

    python3 pypsxserial.py --libps hit-remami/intro.exe /dev/ttyUSB0
